### PR TITLE
[Parser error handling] Exception with text location

### DIFF
--- a/Z3Experiments/Z3Experiments/Parser/PreposeParserException.cs
+++ b/Z3Experiments/Z3Experiments/Parser/PreposeParserException.cs
@@ -1,0 +1,48 @@
+﻿using Antlr4.Runtime;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PreposeGestures
+{
+    public class PreposeParserException : Exception
+    {
+        private readonly int startLineNumber;
+        private readonly int startColumnNumber;
+
+        private readonly int endLineNumber;
+        private readonly int endColumnNumber;
+
+        public int StartLineNumber
+        {
+            get { return this.startLineNumber; }
+        }
+
+        public int StartColumnNumber
+        {
+            get { return this.startColumnNumber; }
+        }
+
+        public int EndLineNumber
+        {
+            get { return this.endLineNumber; }
+        }
+
+        public int EndColumnNumber
+        {
+            get { return this.endColumnNumber; }
+        }
+
+        public PreposeParserException(string message, ParserRuleContext currentContext)
+            : base(message)
+        {
+            this.startLineNumber = currentContext.start.Line;
+            this.startColumnNumber = currentContext.start.Column;
+
+            this.endLineNumber = currentContext.stop.Line;
+            this.endColumnNumber = currentContext.stop.Column;
+        }
+    }
+}

--- a/Z3Experiments/Z3Experiments/Parser/Visitor.cs
+++ b/Z3Experiments/Z3Experiments/Parser/Visitor.cs
@@ -155,7 +155,10 @@ namespace PreposeGestures.Parser
 			{
 				Contract.Assert(s != null);
 				var w = this.Visit(s);
-				Contract.Assert(w != null);
+                if (w == null)
+                {
+                    throw new PreposeParserException("Failed to parse statement", s);
+                }
 				var statement = w.GetValue();
 				if (statement != null)
 				{
@@ -171,14 +174,14 @@ namespace PreposeGestures.Parser
 						continue;
 					}
 
-					throw new ArgumentException("Wrong return type");
+                    throw new PreposeParserException("Invalid return type", s);
 				}
 			}
 
 			var pose = new Pose(context.ID().GetText(), bt, br);
 			if (this.Poses.ContainsKey(pose.Name))
 			{
-				throw new ArgumentException("Pose " + pose.Name + " has been previosly seen.");
+                throw new PreposeParserException("Pose " + pose.Name + " has been previously seen.", context);
 			}
 
 			this.Poses.Add(pose.Name, pose);

--- a/Z3Experiments/Z3Experiments/PreposeGestures.csproj
+++ b/Z3Experiments/Z3Experiments/PreposeGestures.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Parser\PreposeGesturesLexer.cs" />
     <Compile Include="Parser\PreposeGesturesListener.cs" />
     <Compile Include="Parser\PreposeGesturesParser.cs" />
+    <Compile Include="Parser\PreposeParserException.cs" />
     <Compile Include="Parser\PreposeGesturesVisitor.cs" />
     <Compile Include="Gestures\Pose.cs" />
     <Compile Include="Parser\Visitor.cs" />


### PR DESCRIPTION
Hello,
I just slightly modified the visitor class, so when it fails it retrieves the last good known token.
So when calling PreposeGestures.App.ReadAppText(parsedText);
It is now also possible to retrieve a PreposeParserException which contains line/column number where the parser error occurred.

Thanks
Julien
